### PR TITLE
refactor: unify the first letter of props name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const store = createStore(reducer)
 
 ReactDOM.render(
   <Provider store={store}>
-    <SnackbarProvider SnackbarProps={{ autoHideDuration: 3500 }}>
+    <SnackbarProvider snackbarProps={{ autoHideDuration: 3500 }}>
       <App />
     </SnackbarProvider>
   </Provider>,
@@ -56,7 +56,7 @@ ReactDOM.render(
 |Name            |Type        |Default     |Description
 |----------------|------------|------------|--------------------------------
 |children|`node`||The children that are wrapped by this provider.
-|SnackbarProps|`object`||Properties applied to the `Snackbar` element.
+|snackbarProps|`object`||Properties applied to the `Snackbar` element.
 
 ## Usage
 

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -9,7 +9,7 @@ const store = configureStore()
 
 ReactDOM.render(
   <Provider store={store}>
-    <SnackbarProvider SnackbarProps={{ autoHideDuration: 1000 }}>
+    <SnackbarProvider snackbarProps={{ autoHideDuration: 1000 }}>
       <App />
     </SnackbarProvider>
   </Provider>,

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -55,13 +55,13 @@ class SnackbarProvider extends PureComponent {
   }
 
   render () {
-    const { children, SnackbarProps = {} } = this.props
+    const { children, snackbarProps = {} } = this.props
     const { action, message, open } = this.state
 
     return (
       <React.Fragment>
         {children}
-        <Snackbar {...SnackbarProps}
+        <Snackbar {...snackbarProps}
           open={open}
           message={message || ''}
           action={action && (
@@ -83,7 +83,7 @@ SnackbarProvider.childContextTypes = {
 
 SnackbarProvider.propTypes = {
   children: PropTypes.node,
-  SnackbarProps: PropTypes.object
+  snackbarProps: PropTypes.object
 }
 
 export default connect(


### PR DESCRIPTION
Please unify the first letter of props name.

我覺得用小寫開頭當作屬性的名字會比較直覺且通用